### PR TITLE
Add calendar agenda module and UI

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -3,61 +3,463 @@ body {
   margin: 0;
   background: #f4f6fa;
   color: #333;
+  min-height: 100vh;
   display: flex;
   flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  min-height: 100vh;
-  padding: 20px;
+}
+
+.page-wrapper {
+  width: min(1100px, 100%);
+  margin: 0 auto;
+  padding: 48px 24px 64px;
+  display: grid;
+  gap: 40px;
+}
+
+.profile-card {
   text-align: center;
+  background: #ffffff;
+  border-radius: 16px;
+  padding: 32px;
+  box-shadow: 0 16px 40px rgba(15, 23, 42, 0.08);
 }
 
 h1 {
-  font-size: 2.5em;
-  margin-bottom: 0.2em;
+  font-size: clamp(2.2rem, 2vw + 1.5rem, 2.8rem);
+  margin: 16px 0 8px;
 }
 
 p {
-  font-size: 1.2em;
-  margin-bottom: 1.5em;
+  font-size: 1.1rem;
+  margin: 0 auto 24px;
+  max-width: 560px;
 }
 
 .foto-perfil {
-  width: 140px;
-  height: 140px;
+  width: 150px;
+  height: 150px;
   border-radius: 50%;
-  box-shadow: 0 0 10px rgba(0,0,0,0.2);
-  margin-bottom: 1.5em;
+  box-shadow: 0 10px 20px rgba(0, 0, 0, 0.18);
   object-fit: cover;
 }
 
-.construccion {
-  background: #f1f1f1;
-  color: #333;
-  border: 1px solid #ccc;
-  padding: 12px 24px;
-  border-radius: 8px;
-  margin-bottom: 2em;
-  font-weight: bold;
+.profile-actions {
+  display: flex;
+  justify-content: center;
+  gap: 16px;
+  flex-wrap: wrap;
+  margin-bottom: 24px;
 }
 
-a.button {
-  display: inline-block;
-  margin: 10px;
+.button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
   padding: 12px 24px;
-  background: #0077cc;
-  color: #fff;
-  border-radius: 8px;
+  border-radius: 999px;
+  font-weight: 600;
   text-decoration: none;
-  font-weight: bold;
+  border: none;
+  cursor: pointer;
+  background: #0077cc;
+  color: #ffffff;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
 }
 
-a.button:hover {
+.button:hover,
+.button:focus-visible {
+  transform: translateY(-1px);
+  box-shadow: 0 12px 24px rgba(0, 119, 204, 0.25);
   background: #005fa3;
 }
 
+.button--secondary {
+  background: #f4f6fa;
+  color: #0077cc;
+  border: 1px solid rgba(0, 119, 204, 0.2);
+}
+
+.button--secondary:hover,
+.button--secondary:focus-visible {
+  background: rgba(0, 119, 204, 0.08);
+}
+
+.button--ghost {
+  background: transparent;
+  color: #3f4c6b;
+  border: 1px solid rgba(63, 76, 107, 0.2);
+}
+
+.button--ghost:hover,
+.button--ghost:focus-visible {
+  background: rgba(63, 76, 107, 0.1);
+}
+
+.button--danger {
+  background: #e53935;
+}
+
+.button--danger:hover,
+.button--danger:focus-visible {
+  background: #c62828;
+}
+
+.construccion {
+  background: #f1f5f9;
+  color: #1e293b;
+  border: 1px solid rgba(148, 163, 184, 0.4);
+  padding: 12px 24px;
+  border-radius: 12px;
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  font-weight: 600;
+}
+
+.calendar-section {
+  background: #ffffff;
+  border-radius: 20px;
+  padding: 32px;
+  box-shadow: 0 20px 45px rgba(15, 23, 42, 0.1);
+}
+
+.calendar-section__header {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  margin-bottom: 24px;
+}
+
+.calendar-wrapper {
+  display: grid;
+  gap: 24px;
+  grid-template-columns: minmax(0, 1fr) 340px;
+}
+
+.calendar-controls {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.calendar-controls__title {
+  font-size: 1.4rem;
+  text-transform: capitalize;
+}
+
+.calendar-controls__button {
+  background: #f4f6fa;
+  border: none;
+  width: 44px;
+  height: 44px;
+  border-radius: 12px;
+  cursor: pointer;
+  font-size: 1.2rem;
+  transition: background 0.2s ease, transform 0.2s ease;
+}
+
+.calendar-controls__button:hover,
+.calendar-controls__button:focus-visible {
+  background: rgba(0, 119, 204, 0.1);
+  transform: scale(1.05);
+}
+
+.calendar-weekdays {
+  display: grid;
+  grid-template-columns: repeat(7, 1fr);
+  gap: 8px;
+  font-weight: 600;
+  color: #475569;
+  text-transform: uppercase;
+  font-size: 0.85rem;
+}
+
+.calendar-weekday {
+  text-align: center;
+  padding: 4px 0;
+}
+
+.calendar-grid {
+  display: grid;
+  grid-template-columns: repeat(7, minmax(0, 1fr));
+  gap: 8px;
+}
+
+.calendar-cell {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  justify-content: flex-start;
+  gap: 8px;
+  min-height: 90px;
+  border-radius: 16px;
+  padding: 12px;
+  border: 1px solid rgba(148, 163, 184, 0.3);
+  background: #ffffff;
+  cursor: pointer;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease;
+}
+
+.calendar-cell:hover,
+.calendar-cell:focus-visible {
+  border-color: rgba(0, 119, 204, 0.7);
+  box-shadow: 0 12px 24px rgba(15, 23, 42, 0.12);
+  transform: translateY(-1px);
+}
+
+.calendar-cell.is-outside {
+  color: #94a3b8;
+  background: #f8fafc;
+}
+
+.calendar-cell.is-today {
+  border: 1.5px solid #0077cc;
+}
+
+.calendar-cell.is-selected {
+  background: rgba(0, 119, 204, 0.1);
+  border-color: #0077cc;
+}
+
+.calendar-cell__day {
+  font-weight: 600;
+  font-size: 1rem;
+}
+
+.calendar-cell__indicator {
+  position: absolute;
+  right: 10px;
+  top: 10px;
+  width: 26px;
+  height: 26px;
+  border-radius: 50%;
+  background: #0077cc;
+  color: #ffffff;
+  font-size: 0.75rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.event-sidebar {
+  background: #0f172a;
+  border-radius: 18px;
+  padding: 24px;
+  color: #e2e8f0;
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.event-sidebar__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 16px;
+  flex-wrap: wrap;
+}
+
+.event-sidebar__header h3 {
+  margin: 0;
+  font-size: 1.1rem;
+}
+
+.event-sidebar__empty {
+  margin: 0;
+  font-size: 0.95rem;
+  color: rgba(226, 232, 240, 0.8);
+}
+
+.event-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.event-item {
+  background: rgba(15, 23, 42, 0.4);
+  border-radius: 14px;
+  padding: 16px;
+  display: grid;
+  gap: 8px;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.event-item:hover,
+.event-item:focus-visible {
+  transform: translateY(-1px);
+  box-shadow: 0 12px 24px rgba(15, 23, 42, 0.35);
+}
+
+.event-item__title {
+  font-weight: 600;
+  font-size: 1rem;
+}
+
+.event-item__time {
+  font-size: 0.9rem;
+  color: rgba(226, 232, 240, 0.8);
+}
+
+.event-item__description {
+  margin: 0;
+  font-size: 0.9rem;
+  color: rgba(226, 232, 240, 0.75);
+}
+
+.modal-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(15, 23, 42, 0.45);
+  backdrop-filter: blur(2px);
+  z-index: 20;
+}
+
+.modal {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 24px;
+  z-index: 30;
+}
+
+.modal__content {
+  background: #ffffff;
+  border-radius: 20px;
+  width: min(520px, 100%);
+  padding: 28px;
+  box-shadow: 0 30px 60px rgba(15, 23, 42, 0.2);
+}
+
+.modal__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 16px;
+}
+
+.modal__header h2 {
+  margin: 0;
+  font-size: 1.4rem;
+}
+
+.modal__close {
+  background: transparent;
+  border: none;
+  font-size: 1.6rem;
+  line-height: 1;
+  cursor: pointer;
+  color: #475569;
+}
+
+.modal__form {
+  display: grid;
+  gap: 18px;
+}
+
+.form-field {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  text-align: left;
+}
+
+.form-field label {
+  font-weight: 600;
+  color: #334155;
+}
+
+.form-field input,
+.form-field textarea {
+  border-radius: 12px;
+  border: 1px solid rgba(148, 163, 184, 0.6);
+  padding: 12px 14px;
+  font-size: 1rem;
+  font-family: inherit;
+  background: #ffffff;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.form-field input:focus,
+.form-field textarea:focus {
+  border-color: #0077cc;
+  box-shadow: 0 0 0 3px rgba(0, 119, 204, 0.15);
+  outline: none;
+}
+
+.form-grid {
+  display: grid;
+  gap: 16px;
+  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+}
+
+.modal__actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
 footer {
-  margin-top: 2em;
-  font-size: 0.9em;
-  color: #777;
+  text-align: center;
+  padding: 24px;
+  font-size: 0.95rem;
+  color: #64748b;
+  margin-top: auto;
+}
+
+@media (max-width: 1024px) {
+  .calendar-wrapper {
+    grid-template-columns: 1fr;
+  }
+
+  .event-sidebar {
+    order: -1;
+  }
+}
+
+@media (max-width: 768px) {
+  .page-wrapper {
+    padding: 32px 16px 56px;
+  }
+
+  .calendar-section {
+    padding: 24px;
+  }
+
+  .calendar-grid {
+    grid-template-columns: repeat(7, minmax(0, 1fr));
+  }
+
+  .calendar-cell {
+    min-height: 80px;
+  }
+}
+
+@media (max-width: 640px) {
+  .calendar-weekdays,
+  .calendar-grid {
+    gap: 6px;
+  }
+
+  .event-sidebar {
+    padding: 20px;
+  }
+
+  .modal {
+    padding: 16px;
+  }
+
+  .modal__content {
+    padding: 20px;
+  }
 }

--- a/assets/js/calendar.js
+++ b/assets/js/calendar.js
@@ -1,0 +1,405 @@
+const STORAGE_KEY = 'conectadata:calendar-events';
+
+const isLocalStorageAvailable = () => {
+  try {
+    const storage = window.localStorage;
+    const testKey = '__calendar_test__';
+    storage.setItem(testKey, testKey);
+    storage.removeItem(testKey);
+    return true;
+  } catch (error) {
+    console.warn('LocalStorage no disponible. Se usará almacenamiento en memoria.', error);
+    return false;
+  }
+};
+
+class EventRepository {
+  constructor(storageKey) {
+    this.storageKey = storageKey;
+    this.inMemory = [];
+    this.useLocalStorage = isLocalStorageAvailable();
+    this.events = this.load();
+  }
+
+  load() {
+    if (!this.useLocalStorage) {
+      return this.inMemory.slice();
+    }
+
+    const raw = window.localStorage.getItem(this.storageKey);
+    if (!raw) {
+      return [];
+    }
+
+    try {
+      const parsed = JSON.parse(raw);
+      if (Array.isArray(parsed)) {
+        return parsed;
+      }
+      return [];
+    } catch (error) {
+      console.error('No fue posible leer los eventos guardados', error);
+      return [];
+    }
+  }
+
+  persist() {
+    if (this.useLocalStorage) {
+      window.localStorage.setItem(this.storageKey, JSON.stringify(this.events));
+    } else {
+      this.inMemory = this.events.slice();
+    }
+  }
+
+  getAll() {
+    return this.events.slice();
+  }
+
+  upsert(event) {
+    const existingIndex = this.events.findIndex((item) => item.id === event.id);
+    if (existingIndex >= 0) {
+      this.events.splice(existingIndex, 1, { ...event });
+    } else {
+      this.events.push({ ...event });
+    }
+    this.persist();
+    return event;
+  }
+
+  delete(id) {
+    this.events = this.events.filter((event) => event.id !== id);
+    this.persist();
+  }
+}
+
+const formatDateKey = (date) => {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
+};
+
+const getMonthName = (date) => {
+  return date.toLocaleDateString('es-ES', { month: 'long', year: 'numeric' });
+};
+
+const getWeekdayNames = () => {
+  const baseDate = new Date(Date.UTC(2021, 5, 7));
+  const formatter = new Intl.DateTimeFormat('es-ES', { weekday: 'short' });
+  const days = [];
+  for (let i = 0; i < 7; i += 1) {
+    const nextDate = new Date(baseDate);
+    nextDate.setUTCDate(baseDate.getUTCDate() + i);
+    days.push(formatter.format(nextDate).replace('.', ''));
+  }
+  return days;
+};
+
+const generateId = () => {
+  if (typeof crypto !== 'undefined' && crypto.randomUUID) {
+    return crypto.randomUUID();
+  }
+  return `evt-${Date.now()}-${Math.random().toString(16).slice(2, 8)}`;
+};
+
+class CalendarApp {
+  constructor(rootElement, repository) {
+    this.root = rootElement;
+    this.repository = repository;
+    this.state = {
+      events: repository.getAll(),
+      currentMonth: new Date(new Date().getFullYear(), new Date().getMonth(), 1),
+      selectedDate: new Date(),
+      editingEventId: null,
+    };
+
+    this.elements = {
+      monthLabel: this.root.querySelector('[data-role="current-month"]'),
+      grid: this.root.querySelector('[data-role="calendar-grid"]'),
+      weekdayRow: this.root.querySelector('[data-role="weekday-row"]'),
+      selectedDateLabel: this.root.querySelector('[data-role="selected-date"]'),
+      eventList: this.root.querySelector('[data-role="event-list"]'),
+      emptyState: this.root.querySelector('[data-role="empty-state"]'),
+      openFormButton: this.root.querySelector('[data-action="open-form"]'),
+      prevButton: this.root.querySelector('[data-action="prev-month"]'),
+      nextButton: this.root.querySelector('[data-action="next-month"]'),
+    };
+
+    this.modal = document.querySelector('#event-modal');
+    this.modalOverlay = document.querySelector('[data-role="modal-overlay"]');
+    this.eventForm = document.querySelector('#event-form');
+    this.deleteButton = document.querySelector('[data-action="delete-event"]');
+    this.cancelButtons = Array.from(document.querySelectorAll('[data-action="close-modal"]'));
+
+    this.bindEvents();
+    this.renderWeekdays();
+    this.render();
+  }
+
+  bindEvents() {
+    this.elements.prevButton.addEventListener('click', () => {
+      this.changeMonth(-1);
+    });
+
+    this.elements.nextButton.addEventListener('click', () => {
+      this.changeMonth(1);
+    });
+
+    this.elements.grid.addEventListener('click', (event) => {
+      const dayButton = event.target.closest('[data-date]');
+      if (dayButton) {
+        const targetDate = new Date(dayButton.dataset.date);
+        this.state.selectedDate = targetDate;
+        this.state.currentMonth = new Date(targetDate.getFullYear(), targetDate.getMonth(), 1);
+        this.render();
+      }
+    });
+
+    this.elements.openFormButton.addEventListener('click', () => {
+      this.openModal({ date: formatDateKey(this.state.selectedDate) });
+    });
+
+    this.elements.eventList.addEventListener('click', (event) => {
+      const item = event.target.closest('[data-event-id]');
+      if (!item) {
+        return;
+      }
+      const eventId = item.dataset.eventId;
+      const existing = this.state.events.find((evt) => evt.id === eventId);
+      if (existing) {
+        this.openModal(existing);
+      }
+    });
+
+    this.eventForm.addEventListener('submit', (event) => {
+      event.preventDefault();
+      const formData = new FormData(this.eventForm);
+      const payload = {
+        id: formData.get('eventId') || generateId(),
+        title: formData.get('title').trim(),
+        date: formData.get('date'),
+        startTime: formData.get('startTime'),
+        endTime: formData.get('endTime'),
+        description: formData.get('description').trim(),
+      };
+
+      if (!payload.title || !payload.date) {
+        alert('Por favor, indica al menos un título y la fecha del evento.');
+        return;
+      }
+
+      if (payload.startTime && payload.endTime && payload.startTime > payload.endTime) {
+        alert('La hora de inicio no puede ser posterior a la hora de término.');
+        return;
+      }
+
+      this.repository.upsert(payload);
+      this.state.events = this.repository.getAll();
+      this.state.selectedDate = new Date(payload.date);
+      this.state.currentMonth = new Date(this.state.selectedDate.getFullYear(), this.state.selectedDate.getMonth(), 1);
+      this.closeModal();
+      this.render();
+    });
+
+    this.deleteButton.addEventListener('click', () => {
+      const eventId = this.eventForm.querySelector('[name="eventId"]').value;
+      if (!eventId) {
+        return;
+      }
+
+      const confirmation = window.confirm('¿Eliminar este evento?');
+      if (!confirmation) {
+        return;
+      }
+      this.repository.delete(eventId);
+      this.state.events = this.repository.getAll();
+      this.closeModal();
+      this.render();
+    });
+
+    const closeModalHandler = () => this.closeModal();
+    this.cancelButtons.forEach((button) => button.addEventListener('click', closeModalHandler));
+    this.modalOverlay.addEventListener('click', closeModalHandler);
+
+    document.addEventListener('keydown', (event) => {
+      if (event.key === 'Escape' && !this.modal.hasAttribute('hidden')) {
+        this.closeModal();
+      }
+    });
+  }
+
+  changeMonth(offset) {
+    const current = this.state.currentMonth;
+    const newDate = new Date(current.getFullYear(), current.getMonth() + offset, 1);
+    this.state.currentMonth = newDate;
+    this.state.selectedDate = new Date(newDate.getFullYear(), newDate.getMonth(), Math.min(this.state.selectedDate.getDate(), 28));
+    this.render();
+  }
+
+  renderWeekdays() {
+    const weekdays = getWeekdayNames();
+    this.elements.weekdayRow.innerHTML = '';
+    weekdays.forEach((day) => {
+      const cell = document.createElement('div');
+      cell.textContent = day;
+      cell.classList.add('calendar-weekday');
+      this.elements.weekdayRow.appendChild(cell);
+    });
+  }
+
+  render() {
+    this.renderHeader();
+    this.renderGrid();
+    this.renderEventList();
+  }
+
+  renderHeader() {
+    this.elements.monthLabel.textContent = getMonthName(this.state.currentMonth);
+    this.elements.selectedDateLabel.textContent = this.state.selectedDate.toLocaleDateString('es-ES', {
+      weekday: 'long',
+      year: 'numeric',
+      month: 'long',
+      day: 'numeric',
+    });
+  }
+
+  renderGrid() {
+    const { currentMonth, events, selectedDate } = this.state;
+    const firstDay = new Date(currentMonth.getFullYear(), currentMonth.getMonth(), 1);
+    const firstWeekdayIndex = (firstDay.getDay() + 6) % 7; // Convertir a semana iniciando lunes
+    const daysInMonth = new Date(currentMonth.getFullYear(), currentMonth.getMonth() + 1, 0).getDate();
+
+    const cells = [];
+    for (let cellIndex = 0; cellIndex < 42; cellIndex += 1) {
+      const dayNumber = cellIndex - firstWeekdayIndex + 1;
+      const cellDate = new Date(currentMonth.getFullYear(), currentMonth.getMonth(), dayNumber);
+      const isCurrentMonth = cellDate.getMonth() === currentMonth.getMonth();
+      const cell = document.createElement('button');
+      cell.type = 'button';
+      cell.dataset.date = formatDateKey(cellDate);
+      cell.className = 'calendar-cell';
+
+      const label = document.createElement('span');
+      label.textContent = cellDate.getDate();
+      label.classList.add('calendar-cell__day');
+      cell.appendChild(label);
+
+      const dateKey = formatDateKey(cellDate);
+      const eventsForDay = events.filter((event) => event.date === dateKey);
+
+      if (!isCurrentMonth) {
+        cell.classList.add('is-outside');
+      }
+
+      const today = new Date();
+      if (formatDateKey(cellDate) === formatDateKey(today)) {
+        cell.classList.add('is-today');
+      }
+
+      if (formatDateKey(cellDate) === formatDateKey(selectedDate)) {
+        cell.classList.add('is-selected');
+      }
+
+      if (eventsForDay.length > 0) {
+        const indicator = document.createElement('span');
+        indicator.classList.add('calendar-cell__indicator');
+        indicator.textContent = eventsForDay.length;
+        cell.appendChild(indicator);
+      }
+
+      cells.push(cell);
+    }
+
+    this.elements.grid.innerHTML = '';
+    cells.forEach((cell) => this.elements.grid.appendChild(cell));
+  }
+
+  renderEventList() {
+    const selectedKey = formatDateKey(this.state.selectedDate);
+    const eventsForDay = this.state.events
+      .filter((event) => event.date === selectedKey)
+      .sort((a, b) => {
+        if (!a.startTime) return 1;
+        if (!b.startTime) return -1;
+        return a.startTime.localeCompare(b.startTime);
+      });
+
+    this.elements.eventList.innerHTML = '';
+
+    if (eventsForDay.length === 0) {
+      this.elements.emptyState.hidden = false;
+      return;
+    }
+
+    this.elements.emptyState.hidden = true;
+
+    eventsForDay.forEach((event) => {
+      const item = document.createElement('li');
+      item.classList.add('event-item');
+      item.dataset.eventId = event.id;
+
+      const title = document.createElement('div');
+      title.classList.add('event-item__title');
+      title.textContent = event.title;
+
+      const time = document.createElement('div');
+      time.classList.add('event-item__time');
+      if (event.startTime) {
+        const end = event.endTime ? ` – ${event.endTime}` : '';
+        time.textContent = `${event.startTime}${end}`;
+      } else {
+        time.textContent = 'Horario sin definir';
+      }
+
+      const description = document.createElement('p');
+      description.classList.add('event-item__description');
+      description.textContent = event.description || 'Sin descripción adicional';
+
+      item.appendChild(title);
+      item.appendChild(time);
+      item.appendChild(description);
+      this.elements.eventList.appendChild(item);
+    });
+  }
+
+  openModal(event = {}) {
+    this.eventForm.reset();
+    this.modal.removeAttribute('hidden');
+    this.modalOverlay.removeAttribute('hidden');
+
+    this.eventForm.querySelector('[name="eventId"]').value = event.id || '';
+    this.eventForm.querySelector('[name="title"]').value = event.title || '';
+    this.eventForm.querySelector('[name="date"]').value = event.date || formatDateKey(this.state.selectedDate);
+    this.eventForm.querySelector('[name="startTime"]').value = event.startTime || '';
+    this.eventForm.querySelector('[name="endTime"]').value = event.endTime || '';
+    this.eventForm.querySelector('[name="description"]').value = event.description || '';
+
+    if (event.id) {
+      this.deleteButton.removeAttribute('hidden');
+    } else {
+      this.deleteButton.setAttribute('hidden', '');
+    }
+
+    const titleElement = this.modal.querySelector('[data-role="modal-title"]');
+    titleElement.textContent = event.id ? 'Editar evento' : 'Nuevo evento';
+    this.eventForm.querySelector('[name="title"]').focus();
+  }
+
+  closeModal() {
+    this.modal.setAttribute('hidden', '');
+    this.modalOverlay.setAttribute('hidden', '');
+    this.eventForm.reset();
+  }
+}
+
+const initializeCalendar = () => {
+  const root = document.querySelector('[data-calendar-app]');
+  if (!root) {
+    return;
+  }
+  const repository = new EventRepository(STORAGE_KEY);
+  // Sincronización remota podría integrarse aquí en el futuro.
+  new CalendarApp(root, repository); // eslint-disable-line no-new
+};
+
+document.addEventListener('DOMContentLoaded', initializeCalendar);

--- a/index.html
+++ b/index.html
@@ -1,46 +1,136 @@
 <!DOCTYPE html>
 <html lang="es">
   <head>
-  <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <meta name="description" content="Landing profesional de Isabel Figueroa Vargas, ingeniera y consultora en transformación digital" />
-  <title>Isabel Figueroa | Conectadata</title>
-  <link rel="icon" href="assets/img/favicon.ico" type="image/x-icon" />
-  <link rel="stylesheet" href="assets/css/style.css" />
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta
+      name="description"
+      content="Landing profesional de Isabel Figueroa Vargas, ingeniera y consultora en transformación digital"
+    />
+    <title>Isabel Figueroa | Conectadata</title>
+    <link rel="icon" href="assets/img/favicon.ico" type="image/x-icon" />
+    <link rel="stylesheet" href="assets/css/style.css" />
 
-  <!-- Google tag (gtag.js) -->
-  <script async src="https://www.googletagmanager.com/gtag/js?id=G-444CXTLPBJ"></script>
-  <script>
-    window.dataLayer = window.dataLayer || [];
-    function gtag(){dataLayer.push(arguments);}
-    gtag('js', new Date());
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-444CXTLPBJ"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
 
-    gtag('config', 'G-444CXTLPBJ');
-  </script>
-</head>
-  <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <meta name="description" content="Landing profesional de Isabel Figueroa Vargas, ingeniera y consultora en transformación digital" />
-  <title>Isabel Figueroa | Conectadata</title>
-  <link rel="icon" href="assets/img/favicon.ico" type="image/x-icon" />
-  <link rel="stylesheet" href="assets/css/style.css" />
-</head>
-<body>
-  <img src="assets/img/isa.jpg" alt="Fotografía de Isabel Figueroa" class="foto-perfil" />
-  <h1>Isabel Figueroa Vargas</h1>
-  <p>Ingeniera y Consultora en Transformación Digital<br>
-     Aplico IA, Python y React para soluciones inteligentes</p>
+      gtag('config', 'G-444CXTLPBJ');
+    </script>
+  </head>
+  <body>
+    <main class="page-wrapper">
+      <section class="profile-card" aria-labelledby="profile-title">
+        <img src="assets/img/isa.jpg" alt="Fotografía de Isabel Figueroa" class="foto-perfil" />
+        <h1 id="profile-title">Isabel Figueroa Vargas</h1>
+        <p>
+          Ingeniera y Consultora en Transformación Digital<br />
+          Aplico IA, Python y React para soluciones inteligentes
+        </p>
 
-  <div class="construccion">🔧 Sitio en construcción · Pronto disponible</div>
+        <div class="profile-actions">
+          <a
+            href="https://github.com/IsabelFigueroaV"
+            class="button"
+            target="_blank"
+            rel="noopener noreferrer"
+            >GitHub</a
+          >
+          <a
+            href="https://www.linkedin.com/in/isabelfigueroav/?utm_medium=social&utm_source=landing&utm_campaign=perfil"
+            class="button"
+            target="_blank"
+            rel="noopener noreferrer"
+            >LinkedIn</a
+          >
+          <a href="mailto:isabelfigueroavargas@rrhh1313.onmicrosoft.com" class="button">Contacto</a>
+        </div>
+        <div class="construccion">🔧 Sitio en construcción · Pronto disponible</div>
+      </section>
 
-  <div>
-    <a href="https://github.com/IsabelFigueroaV" class="button" target="_blank" rel="noopener noreferrer">GitHub</a>
-    <a href="https://www.linkedin.com/in/isabelfigueroav/?utm_medium=social&utm_source=landing&utm_campaign=perfil" class="button" target="_blank" rel="noopener noreferrer">LinkedIn</a>
-    <a href="mailto:isabelfigueroavargas@rrhh1313.onmicrosoft.com" class="button">Contacto</a>
-  </div>
+      <section class="calendar-section" aria-labelledby="calendar-title">
+        <div class="calendar-section__header">
+          <h2 id="calendar-title">Agenda profesional</h2>
+          <p>Organiza reuniones, seguimientos y recordatorios clave desde cualquier dispositivo.</p>
+        </div>
 
-  <footer>
-    © 2025 Conectadata · Todos los derechos reservados
-  </footer>
-</body>
+        <div class="calendar-wrapper" data-calendar-app>
+          <header class="calendar-controls">
+            <button type="button" class="calendar-controls__button" data-action="prev-month" aria-label="Mes anterior">
+              ◀
+            </button>
+            <h3 class="calendar-controls__title" data-role="current-month"></h3>
+            <button type="button" class="calendar-controls__button" data-action="next-month" aria-label="Mes siguiente">
+              ▶
+            </button>
+          </header>
+
+          <div class="calendar-weekdays" data-role="weekday-row" aria-hidden="true"></div>
+          <div class="calendar-grid" data-role="calendar-grid" role="grid" aria-label="Calendario mensual"></div>
+
+          <aside class="event-sidebar">
+            <header class="event-sidebar__header">
+              <h3>Eventos del <span data-role="selected-date"></span></h3>
+              <button type="button" class="button button--secondary" data-action="open-form">Añadir evento</button>
+            </header>
+            <p class="event-sidebar__empty" data-role="empty-state" hidden>
+              No hay eventos programados para esta fecha.
+            </p>
+            <ul class="event-list" data-role="event-list" aria-live="polite"></ul>
+          </aside>
+        </div>
+      </section>
+    </main>
+
+    <div class="modal-overlay" data-role="modal-overlay" hidden></div>
+    <section class="modal" id="event-modal" role="dialog" aria-modal="true" aria-labelledby="modal-title" hidden>
+      <div class="modal__content">
+        <header class="modal__header">
+          <h2 id="modal-title" data-role="modal-title">Nuevo evento</h2>
+          <button type="button" class="modal__close" data-action="close-modal" aria-label="Cerrar">
+            ×
+          </button>
+        </header>
+        <form id="event-form" class="modal__form">
+          <input type="hidden" name="eventId" />
+          <div class="form-field">
+            <label for="event-title">Título *</label>
+            <input id="event-title" name="title" type="text" placeholder="Reunión, entrega, workshop..." required />
+          </div>
+          <div class="form-grid">
+            <div class="form-field">
+              <label for="event-date">Fecha *</label>
+              <input id="event-date" name="date" type="date" required />
+            </div>
+            <div class="form-field">
+              <label for="event-start">Hora inicio</label>
+              <input id="event-start" name="startTime" type="time" />
+            </div>
+            <div class="form-field">
+              <label for="event-end">Hora fin</label>
+              <input id="event-end" name="endTime" type="time" />
+            </div>
+          </div>
+          <div class="form-field">
+            <label for="event-description">Notas</label>
+            <textarea id="event-description" name="description" rows="3" placeholder="Objetivos, enlaces o recordatorios"></textarea>
+          </div>
+          <div class="modal__actions">
+            <button type="button" class="button button--ghost" data-action="close-modal">Cancelar</button>
+            <button type="button" class="button button--danger" data-action="delete-event" hidden>Eliminar</button>
+            <button type="submit" class="button">Guardar</button>
+          </div>
+        </form>
+      </div>
+    </section>
+
+    <footer>
+      © 2025 Conectadata · Todos los derechos reservados
+    </footer>
+
+    <script type="module" src="assets/js/calendar.js"></script>
+  </body>
 </html>


### PR DESCRIPTION
## Summary
- create a standalone calendar module with localStorage-backed event management
- add an agenda section with calendar grid, event list, and modal forms to the landing page
- refresh global styling to support the responsive calendar experience

## Testing
- Manual validation in browser (Playwright screenshot)


------
https://chatgpt.com/codex/tasks/task_e_68e4fafb1478832f95c023d452d78360